### PR TITLE
feat: Fix docker startup script, Attach service account to instance via instance template(terraform)

### DIFF
--- a/scripts/cicd/docker-startup-script.sh
+++ b/scripts/cicd/docker-startup-script.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+echo "▶️ 필수 디렉토리 생성"
+mkdir -p /home/ubuntu/backend
+mkdir -p /var/log/onthetop/backend
+chown -R ubuntu:ubuntu /var/log/onthetop/backend
+
+echo "▶️ Docker 설치"
+if ! command -v docker &> /dev/null; then
+  apt-get update && apt-get install -y docker.io
+fi
+
+echo "▶️ GCP Secret Manager에서 secrets.properties 가져오기"
+
+SECRETS_FILE="/home/ubuntu/backend/secrets.properties"
+mkdir -p "$(dirname "$SECRETS_FILE")"
+touch "$SECRETS_FILE"
+
+SECRET_NAME="onthetop-backend-secrets"
+SECRET_LABELS="backend_shared backend_prod"
+
+for LABEL in $SECRET_LABELS; do
+  gcloud secrets list --filter="labels.env=$LABEL" --format="value(name)" | while read SECRET_NAME; do
+    SECRET_VALUE=$(gcloud secrets versions access latest --secret="$SECRET_NAME")
+    IFS='-' read -r SERVICE KEY ENV <<< "$SECRET_NAME"
+    echo "${KEY}=${SECRET_VALUE}" >> "$SECRETS_FILE"
+  done
+done
+
+chown ubuntu:ubuntu "$SECRETS_FILE"
+
+echo "▶️ GCP Secret Manager에서 확정된 Docker 버전 가져오기"
+RAW_VERSION=$(gcloud secrets versions access latest --secret=confirmed-backend-version | tr -d '\r\n ')
+DOCKER_VERSION="v${RAW_VERSION}"
+echo "✅ CONFIRMED_VERSION = $DOCKER_VERSION"
+
+echo "▶️ Docker 이미지 pull 및 실행"
+docker pull luckyprice1103/onthetop-backend:$DOCKER_VERSION
+
+docker run -d \
+  --name onthetop-backend-blue \
+  -p 8080:8080 \
+  --memory=512m \
+  --cpus=0.5 \
+  -v /home/ubuntu/backend/secrets.properties:/app/secrets.properties \
+  -v /var/log/onthetop/backend:/logs \
+  -e SPRING_PROFILES_ACTIVE=prod \
+  luckyprice1103/onthetop-backend:$DOCKER_VERSION \
+  --logging.file.name=/logs/backend.log \
+  --spring.config.additional-location=file:/app/secrets.properties
+
+echo "▶️ Nginx 설치 및 설정"
+apt-get install -y nginx
+
+cat <<EOF > /etc/nginx/sites-available/backend
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    }
+}
+EOF
+
+ln -sf /etc/nginx/sites-available/backend /etc/nginx/sites-enabled/backend
+rm -f /etc/nginx/sites-enabled/default
+
+nginx -t && systemctl restart nginx
+
+echo "✅ 컨테이너 및 Nginx 기동 완료: onthetop-backend:$DOCKER_VERSION"

--- a/terraform/gcp/envs/prod/locals.tf
+++ b/terraform/gcp/envs/prod/locals.tf
@@ -25,7 +25,7 @@ locals {
     http = {
       name          = "http"
       port          = ["80"]
-      source_ranges = ["10.0.0.0/8"]
+      source_ranges = ["10.0.0.0/8", "130.211.0.0/22", "35.191.0.0/16"]
       tag_suffix    = "http"
     },
     https = {

--- a/terraform/gcp/envs/prod/main.tf
+++ b/terraform/gcp/envs/prod/main.tf
@@ -91,6 +91,10 @@ module "backend_template" {
   image          = var.backend_image
   subnetwork     = module.subnet_private.self_link
   startup_script_path = "../../../../scripts/cicd/docker-startup-script.sh"
+  service_account = {
+    email  = "onthetop-sa-secret-manager@onlinevoting-378808.iam.gserviceaccount.com"
+    scopes = ["cloud-platform"]
+    }
   tags = [
     for name in ["ssh", "http", "https", "monitoring", "backend"] : local.firewall_expanded_rules[name].tag
   ]
@@ -101,7 +105,7 @@ module "backend_health_check" {
   name        = "backend-health-check"
   project_id  = var.project_id
   protocol    = "HTTP"
-  port        = 8080
+  port        = 80
   request_path = "/api/v1/health"
 }
 
@@ -113,7 +117,7 @@ module "backend_mig" {
   instance_template  = module.backend_template.template_self_link
   target_size        = 1
   named_port         = "http"
-  port               = 8080
+  port               = 80
   health_check       = module.backend_health_check.self_link # 없으면 null
   update_policy = {
     type                   = "PROACTIVE"

--- a/terraform/gcp/envs/shared/locals.tf
+++ b/terraform/gcp/envs/shared/locals.tf
@@ -24,7 +24,7 @@ locals {
       name          = "http"
       port          = ["80"]
       protocols     = ["tcp"] 
-      source_ranges = ["10.0.0.0/8"]
+      source_ranges = ["10.0.0.0/8", "130.211.0.0/22", "35.191.0.0/16"]
       tag_suffix    = "http"
     },
     https = {

--- a/terraform/gcp/modules/instance-template/main.tf
+++ b/terraform/gcp/modules/instance-template/main.tf
@@ -10,6 +10,11 @@ resource "google_compute_instance_template" "this" {
     boot         = true
   }
 
+  service_account {
+    email  = var.service_account.email
+    scopes = var.service_account.scopes
+  }
+
   network_interface {
     subnetwork         = var.subnetwork
   }

--- a/terraform/gcp/modules/instance-template/variables.tf
+++ b/terraform/gcp/modules/instance-template/variables.tf
@@ -6,3 +6,10 @@ variable "image" { type = string }
 variable "subnetwork" { type = string }
 variable "startup_script_path" { type = string }
 variable "tags" { type = list(string) }
+variable "service_account" {
+  type = object({
+    email  = string
+    scopes = list(string)
+  })
+  description = "Service account to attach to the VM"
+}


### PR DESCRIPTION
##  변경 내용

* startup script : GCP Secret Manager에서 버전 및 secrets 가져와 Docker 컨테이너 자동 실행
* instance template에 service account 설정 추가 (Secret Manager 접근용)

## 적용 방식

* MIG로 service account가 추가되어 생성된 인스턴스에서 startup script 실행
* Secret Manager에 접속후 시크릿 도커의 최신 버전을 가져와 secrets.properties 생성 후, 지정된 Docker 이미지 실행
* Secret Manager에 저장된는 도커의 최신 버전은 confirm파일을 사용하여 확정할때 새로 갱신. 이전버전으로 Secret Manager 버전을 돌리고 싶다면 다시 이전버전 배포 -> 이전 버전 확정 단계 진행.
* 새로 시작되는 도커는 무조건 blue(8080)에서 실행
