### PR TITLE
CNN 서버 yaml 파일

### DIFF
--- a/kubernetes/cnn/onthetop-cnn.yaml
+++ b/kubernetes/cnn/onthetop-cnn.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onthetop-cnn
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: onthetop-cnn
+  template:
+    metadata:
+      labels:
+        app: onthetop-cnn
+    spec:
+      containers:
+        - name: cnn
+          image: luckyprice1103/onthetop-cnn:latest
+          ports:
+            - containerPort: 8000
+          # env:
+          #   - name: CNN_MODEL
+          #     value: /app/models/desk_classify.h5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: onthetop-cnn
+spec:
+  selector:
+    app: onthetop-cnn
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP


### PR DESCRIPTION
kubectl apply 를 통해서 적용할 수 있는 yaml 파일입니다.

외부 노출 없이 내부 ClusterIP 서비스만을 가지고 있어, 백엔드 서비스가 사진의 정답 유무를 확인할 수 있습니다.